### PR TITLE
Fix bin directory handling in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,9 +1,9 @@
 all:
-	mkdir bin/
+	mkdir -p bin/
 	cd src/ && make
 	cd src/ && make clean
 clean:
-	rm -r bin/
+	rm -rf bin/
 
 run:
 	cd bin && ./words


### PR DESCRIPTION
## Summary
- use `mkdir -p` so make does not fail if `bin` already exists
- use `rm -rf` for robust cleanup

## Testing
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_684001d9ce9c83229656d722f549f9c7